### PR TITLE
Fixed the case when editor's holder is HtmlElement

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -33,7 +33,7 @@ export default class Observer {
       characterDataOldValue: true,
     };
 
-    const target = document.querySelector(`#${this.holder}`);
+    const target = typeof this.holder === 'string' ? document.querySelector(`#${this.holder}`) : this.holder;
 
     this.observer = new MutationObserver((mutationList) => {
       this.mutationHandler(mutationList);


### PR DESCRIPTION
Editor's holder can be either a string (element id) or HtmlElement itself
see https://github.com/codex-team/editor.js/blob/next/types/configs/editor-config.d.ts