### PR TITLE
Change listener-targets to holder | Check readOnly props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,12 +81,19 @@ export default class Undo {
    * Registers the data returned by API's save method into the history stack.
    */
   registerChange() {
-    if (this.editor && this.editor.save && this.shouldSaveHistory) {
-      this.editor.save().then((savedData) => {
-        if (this.editorDidUpdate(savedData.blocks)) this.save(savedData.blocks);
-      });
+    if(this.editor){
+      const {configuration} = this.editor;
+      if(configuration && configuration.readOnly){
+        return;
+      }
+      const {save} = this.editor;
+      if (save && this.shouldSaveHistory) {
+        save().then((savedData) => {
+          if (this.editorDidUpdate(savedData.blocks)) this.save(savedData.blocks);
+        });
+      }
+      this.shouldSaveHistory = true;
     }
-    this.shouldSaveHistory = true;
   }
 
   /**
@@ -195,13 +202,17 @@ export default class Undo {
       }
     };
 
+    // Add/Remove the listeners only to/from the holder-element (if possible)
+    const {holder} = this.editor.configuration;
+    const eventable = holder?document.getElementById(holder):document;
+
     const handleDestroy = () => {
-      document.removeEventListener('keydown', handleUndo);
-      document.removeEventListener('keydown', handleRedo);
+      eventable.removeEventListener('keydown', handleUndo);
+      eventable.removeEventListener('keydown', handleRedo);
     };
 
-    document.addEventListener('keydown', handleUndo);
-    document.addEventListener('keydown', handleRedo);
-    document.addEventListener('destroy', handleDestroy);
+    eventable.addEventListener('keydown', handleUndo);
+    eventable.addEventListener('keydown', handleRedo);
+    eventable.addEventListener('destroy', handleDestroy);
   }
 }


### PR DESCRIPTION
### Two main changes

1. Adding support for the `readOnly` field by ignoring **save** callbacks: If an editor-instance is **read-only**, then, an error will occur from EditorJS module and that's no good! in a read-only editor, we don't typically need any changes or undo/redo.

2. Adding support for having multiple-editors in a document. previously, the **listeners** were being added to the whole `document`, but we don't want that! we wanna add an undo/redo for the specific editor-instance we just instantiated. So if we have a `holder` id, (i.e. the holder element that editor-js is onto it), then we can attach the listeners to that specific element.