### PR TITLE
49 - accept strings in the holder key in editorjs-undo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,8 +22,9 @@ export default class Undo {
     };
 
     const { configuration } = editor;
+    const { holder } = configuration;
 
-    this.holder = typeof configuration.holder === 'string' ? document.getElementById(configuration.holder) : configuration.holder;
+    this.holder = typeof holder === 'string' ? document.getElementById(holder) : holder;
     this.editor = editor;
     this.shouldSaveHistory = true;
     this.readOnly = configuration.readOnly;

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ export default class Undo {
 
     const { configuration } = editor;
 
+    this.holder = typeof configuration.holder === 'string' ? document.getElementById(configuration.holder) : configuration.holder;
     this.editor = editor;
     this.shouldSaveHistory = true;
     this.readOnly = configuration.readOnly;
@@ -31,11 +32,11 @@ export default class Undo {
 
     const observer = new Observer(
       () => this.registerChange(),
-      configuration.holder,
+      this.holder,
     );
     observer.setMutationObserver();
 
-    this.setEventListeners(observer.holder);
+    this.setEventListeners();
     this.initialItem = null;
     this.clear();
   }
@@ -189,8 +190,8 @@ export default class Undo {
   /**
    * Sets events listeners to allow keyboard actions support.
    */
-  setEventListeners(observerHolder) {
-    const holder = observerHolder;
+  setEventListeners() {
+    const { holder } = this;
     const buttonKey = /(Mac)/i.test(navigator.platform) ? 'metaKey' : 'ctrlKey';
 
     const handleUndo = (e) => {

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ export default class Undo {
     );
     observer.setMutationObserver();
 
-    this.setEventListeners();
+    this.setEventListeners(observer.holder);
     this.initialItem = null;
     this.clear();
   }
@@ -189,8 +189,8 @@ export default class Undo {
   /**
    * Sets events listeners to allow keyboard actions support.
    */
-  setEventListeners() {
-    const { holder } = this.editor.configuration;
+  setEventListeners(observerHolder) {
+    const holder = observerHolder;
     const buttonKey = /(Mac)/i.test(navigator.platform) ? 'metaKey' : 'ctrlKey';
 
     const handleUndo = (e) => {

--- a/src/observer.js
+++ b/src/observer.js
@@ -13,7 +13,7 @@ export default class Observer {
    * @param {String} holder - Editor.js holder id.
    */
   constructor(registerChange, holder) {
-    this.holder = typeof holder === 'string' ? document.getElementById(holder) : holder;
+    this.holder = holder;
     this.observer = null;
     this.debounceTimer = 200;
     this.mutationDebouncer = this.debounce(() => {

--- a/test/undo.test.js
+++ b/test/undo.test.js
@@ -199,4 +199,28 @@ describe('Undo', () => {
       expect(state).toEqual(secondChange.blocks);
     });
   });
+
+  describe('the holder key accept strings', () => {
+    let undo;
+
+    beforeEach(() => {
+      editor.configuration.holder = 'editorjs';
+      undo = new Undo({ editor });
+      undo.initialize(initialData.blocks);
+      undo.save(firstChange.blocks);
+      undo.save(secondChange.blocks);
+    });
+
+    it('holder is assign to the correct html element', () => {
+      expect(undo.holder).toBe(document.querySelector('#editorjs'));
+    });
+
+    it('performs an undo and redo operation with two changes', () => {
+      undo.undo();
+      undo.redo();
+      expect(undo.position).toEqual(undo.count());
+      const { state } = undo.stack[undo.position];
+      expect(state).toEqual(secondChange.blocks);
+    });
+  });
 });


### PR DESCRIPTION
Main issue: 
If editor.js was instanced with the default configuration (the holder key as 'editorjs'), editorjs-undo did not work. 

Solution: 
In the code, there was an error when some eventListeners were assigned to the holder value, when the holder was a string, they were been assigned to a string. The solution was to use the holder as the corresponding HTML element to the eventListeners.

- fix #49  