### PR TITLE
#48 Add the custom shortcuts feature and the respective tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,54 @@ const editor = new EditorJS({
 });
 ```
 
+### Add a custom shortcut to undo and redo
+
+**Note:** If you do not add any shortcut, the default shortcuts will be set up.
+
+If you want to add custom shortcuts, add a new Tool to the `tools` property of the Editor.js initial config, then pass the shortcuts inside the config property, the shortcuts must be called `undo` and `redo`.
+
+```javascript
+const config = {
+  shortcuts: {
+    undo: 'ctrlKey+x',
+    redo: 'ctrlKey+altKey+c'
+  }
+}
+const editor = new EditorJS({
+  tools: {
+    undo : {
+      class: Undo,
+      config: config,
+    },
+  }
+});
+```
+You can set up each shortcut with two or three keys, remember the special keys (ctrlKey, altKey, shiftKey, metaKey). 
+
+Finally, you must pass the config property in the undo instance. 
+
+```javascript
+const config = {
+  shortcuts: {
+    undo: 'ctrlKey+x',
+    redo: 'ctrlKey+altKey+c'
+  }
+}
+const editor = new EditorJS({
+  holder: 'editorjs',
+  tools: {
+    undo: {
+      class: Undo,
+      config: config,
+    },
+  },
+
+  onReady: () => {
+    const undo = new Undo({ editor, config });
+  },
+});
+```
+
 ### Available Options
 
 | Field      | Type       | Description                                                    |
@@ -58,6 +106,7 @@ const editor = new EditorJS({
 | editor     | `EditorJS`   | **Required.** The EditorJS instance.                         |
 | maxLength  | `Number`   | Max amount of changes recorded by the history stack.           |
 | onUpdate() | `function` | Callback called when the user performs an undo or redo action. |
+| config     | `object`   | Set up the configuration to editorjs-undo like the shortcuts   |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ If you want to add custom shortcuts, pass a config object with a shortcut key in
 ```javascript
 const config = {
   shortcuts: {
-    undo: 'ctrlKey+x',
-    redo: 'ctrlKey+altKey+c'
+    undo: 'CMD+X',
+    redo: 'CMD+ALT+C'
   }
 }
 const editor = new EditorJS({
@@ -71,7 +71,7 @@ const editor = new EditorJS({
 });
 ```
 
-You can set each shortcut with two or three keys, remember the special keys (ctrlKey, altKey, shiftKey, metaKey). 
+You can set each shortcut with two or three keys, the available special keys are: CMD, ALT, SHIFT. CMD will be set up automatically as <kbd>Ctrl</kbd> or <kbd>⌘</kbd> depending on your OS.
 
 ### Available Options
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const editor = new EditorJS({
 
 **Note:** If you do not add any shortcut, the default shortcuts will be set up.
 
-If you want to add custom shortcuts, add a new Tool to the `tools` property of the Editor.js initial config, then pass the shortcuts inside the config property, the shortcuts must be called `undo` and `redo`.
+If you want to add custom shortcuts, pass a config object with a shortcut key in the undo instance, the shortcuts must be called `undo` and `redo`.
 
 ```javascript
 const config = {
@@ -65,39 +65,13 @@ const config = {
   }
 }
 const editor = new EditorJS({
-  tools: {
-    undo : {
-      class: Undo,
-      config: config,
-    },
-  }
-});
-```
-You can set up each shortcut with two or three keys, remember the special keys (ctrlKey, altKey, shiftKey, metaKey). 
-
-Finally, you must pass the config property in the undo instance. 
-
-```javascript
-const config = {
-  shortcuts: {
-    undo: 'ctrlKey+x',
-    redo: 'ctrlKey+altKey+c'
-  }
-}
-const editor = new EditorJS({
-  holder: 'editorjs',
-  tools: {
-    undo: {
-      class: Undo,
-      config: config,
-    },
-  },
-
   onReady: () => {
     const undo = new Undo({ editor, config });
   },
 });
 ```
+
+You can set each shortcut with two or three keys, remember the special keys (ctrlKey, altKey, shiftKey, metaKey). 
 
 ### Available Options
 

--- a/src/index.js
+++ b/src/index.js
@@ -211,7 +211,8 @@ export default class Undo {
       SHIFT: 'shiftKey',
     };
     const parsedKeys = keys.slice(0, -1).map((key) => specialKeys[key]);
-    const letterKey = parsedKeys.includes('shiftKey') ? keys[keys.length - 1].toUpperCase() : keys[keys.length - 1].toLowerCase();
+    const lastItem = keys[keys.length - 1];
+    const letterKey = parsedKeys.includes('shiftKey') ? lastItem.toUpperCase() : lastItem.toLowerCase();
     parsedKeys.push(letterKey);
     return parsedKeys;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,10 @@ export default class Undo {
     this.maxLength = maxLength || defaultOptions.maxLength;
     this.onUpdate = onUpdate || defaultOptions.onUpdate;
 
+    const buttonKey = /(Mac)/i.test(navigator.platform) ? 'metaKey' : 'ctrlKey';
+    this.shortcutUndo = `${buttonKey}+z`;
+    this.shortcutRedo = `${buttonKey}+y`;
+
     const observer = new Observer(
       () => this.registerChange(),
       this.holder,
@@ -189,34 +193,42 @@ export default class Undo {
   }
 
   /**
-   * Sets events listeners to allow keyboard actions support.
+   * Sets up the shortcuts to undo and redo
+   * @param {string} shortcutUndo shortcut to the Undo action, it is by default ctrlKey+z
+   * @param {string} shortcutRedo shortcut to the Redo action, it is by default ctrlKey+y
    */
+
+  shortcut(shortcutUndo = this.shortcutUndo, shortcutRedo = this.shortcutRedo) {
+    this.shortcutRedo = shortcutRedo;
+    this.shortcutUndo = shortcutUndo;
+  }
+
+  /**
+   * Sets events listeners to allow keyboard actions support
+   */
+
   setEventListeners() {
     const { holder } = this;
-    const buttonKey = /(Mac)/i.test(navigator.platform) ? 'metaKey' : 'ctrlKey';
 
     const handleUndo = (e) => {
-      if (e[buttonKey] && e.key === 'z') {
+      const buttonKeyUndo = this.shortcutUndo.replace(/ /g, '').split('+')[0];
+      const keyUndo = this.shortcutUndo.replace(/ /g, '').split('+')[1];
+      if (e[buttonKeyUndo] && e.key === keyUndo) {
         e.preventDefault();
         this.undo();
       }
     };
 
     const handleRedo = (e) => {
-      if (e[buttonKey] && e.key === 'y') {
+      const buttonKeyRedo = this.shortcutRedo.replace(/ /g, '').split('+')[0];
+      const keyRedo = this.shortcutRedo.replace(/ /g, '').split('+')[1];
+      if (e[buttonKeyRedo] && e.key === keyRedo) {
         e.preventDefault();
         this.redo();
       }
     };
 
-    const handleDestroy = () => {
-      holder.removeEventListener('keydown', handleUndo);
-      holder.removeEventListener('keydown', handleRedo);
-    };
-
     holder.addEventListener('keydown', handleUndo);
     holder.addEventListener('keydown', handleRedo);
-    holder.addEventListener('destroy', handleDestroy);
   }
-
 }

--- a/src/index.js
+++ b/src/index.js
@@ -206,13 +206,15 @@ export default class Undo {
 
   parseKeys(keys) {
     const specialKeys = {
-      CMD: (/(Mac)/i.test(navigator.platform) ? 'metaKey' : 'ctrlKey'),
+      CMD: /(Mac)/i.test(navigator.platform) ? 'metaKey' : 'ctrlKey',
       ALT: 'altKey',
       SHIFT: 'shiftKey',
     };
     const parsedKeys = keys.slice(0, -1).map((key) => specialKeys[key]);
-    const lastItem = keys[keys.length - 1];
-    const letterKey = parsedKeys.includes('shiftKey') ? lastItem.toUpperCase() : lastItem.toLowerCase();
+    const letterKey = parsedKeys.includes('shiftKey')
+      ? keys[keys.length - 1].toUpperCase()
+      : keys[keys.length - 1].toLowerCase();
+
     parsedKeys.push(letterKey);
     return parsedKeys;
   }
@@ -233,7 +235,9 @@ export default class Undo {
 
     const pressedKeys = (e, keys) => {
       if (keys.length === 2 && e[keys[0]] && e.key === keys[1]) return true;
-      if (keys.length === 3 && e[keys[0]] && e[keys[1]] && e.key === keys[2]) return true;
+      if (keys.length === 3 && e[keys[0]] && e[keys[1]] && e.key === keys[2]) {
+        return true;
+      }
       return false;
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default class Undo {
   /**
    * @param options — Plugin custom options.
    */
-  constructor({ editor, config, onUpdate, maxLength }) {
+  constructor({ editor, config = {}, onUpdate, maxLength }) {
     const buttonKey = /(Mac)/i.test(navigator.platform) ? 'metaKey' : 'ctrlKey';
     const defaultOptions = {
       maxLength: 30,
@@ -30,6 +30,8 @@ export default class Undo {
 
     const { configuration } = editor;
     const { holder } = configuration;
+    const defaultShortcuts = defaultOptions.config.shortcuts;
+    const { shortcuts = defaultShortcuts } = config;
 
     this.holder = typeof holder === 'string' ? document.getElementById(holder) : holder;
     this.editor = editor;
@@ -37,17 +39,7 @@ export default class Undo {
     this.readOnly = configuration.readOnly;
     this.maxLength = maxLength || defaultOptions.maxLength;
     this.onUpdate = onUpdate || defaultOptions.onUpdate;
-    this.config = {
-      shortcuts: {
-        undo: defaultOptions.config.shortcuts.undo,
-        redo: defaultOptions.config.shortcuts.redo,
-      },
-    };
-
-    if (config && config.shortcuts) {
-      this.config.shortcuts.undo = config.shortcuts.undo;
-      this.config.shortcuts.redo = config.shortcuts.redo;
-    }
+    this.config = { shortcuts };
 
     const observer = new Observer(
       () => this.registerChange(),
@@ -213,8 +205,10 @@ export default class Undo {
 
   setEventListeners() {
     const { holder } = this;
-    const keysUndo = this.config.shortcuts.undo.replace(/ /g, '').split('+');
-    const keysRedo = this.config.shortcuts.redo.replace(/ /g, '').split('+');
+    const { shortcuts } = this.config;
+    const { undo, redo } = shortcuts;
+    const keysUndo = undo.replace(/ /g, '').split('+');
+    const keysRedo = redo.replace(/ /g, '').split('+');
 
     const pressedKeys = (e, keys) => {
       if (keys.length === 2 && e[keys[0]] && e.key === keys[1]) return true;

--- a/test/fixtures/editor.js
+++ b/test/fixtures/editor.js
@@ -29,4 +29,15 @@ const readOnlyEditor = {
   },
 };
 
-export { editor, readOnlyEditor };
+const tools = {
+  undo: {
+    config: {
+      shortcuts: {
+        undo: 'ctrlKey+x',
+        redo: 'ctrlKey+altKey+c',
+      },
+    },
+  },
+};
+
+export { editor, readOnlyEditor, tools };

--- a/test/fixtures/editor.js
+++ b/test/fixtures/editor.js
@@ -33,8 +33,8 @@ const tools = {
   undo: {
     config: {
       shortcuts: {
-        undo: 'ctrlKey+x',
-        redo: 'ctrlKey+altKey+c',
+        undo: 'CMD+X',
+        redo: 'CMD+C',
       },
     },
   },

--- a/test/undo.test.js
+++ b/test/undo.test.js
@@ -5,7 +5,7 @@ import {
   secondChange,
   newChange,
 } from './fixtures/data';
-import { editor, readOnlyEditor } from './fixtures/editor';
+import { editor, readOnlyEditor, tools } from './fixtures/editor';
 
 describe('Undo', () => {
   beforeEach(() => {
@@ -124,7 +124,7 @@ describe('Undo', () => {
     });
   });
 
-  describe('Undo/redo events fired inside and outside Editor\'s holder', () => {
+  describe('Undo/redo events fired inside and outside Editor\'s holder with default shortcuts', () => {
     let undo;
 
     beforeEach(() => {
@@ -134,7 +134,7 @@ describe('Undo', () => {
       undo.save(secondChange.blocks);
     });
 
-    it('undo event, with default shortcut, outside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
+    it('undo event outside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
       // Set metaKey and ctrlKey to true in order to work in Mac and other OSs.
       const keyboardEvent = new KeyboardEvent('keydown', {
         key: 'z',
@@ -150,7 +150,7 @@ describe('Undo', () => {
       expect(state).toEqual(secondChange.blocks);
     });
 
-    it('undo event, with default shortcut, inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
+    it('undo event inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
       const keyboardEvent = new KeyboardEvent('keydown', {
         key: 'z',
         metaKey: true,
@@ -165,39 +165,7 @@ describe('Undo', () => {
       expect(state).toEqual(firstChange.blocks);
     });
 
-    it('undo event, with custom shortcut, inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
-      undo.shortcut('ctrlKey+x', 'ctrlKey+c');
-      const keyboardEvent = new KeyboardEvent('keydown', {
-        key: 'x',
-        metaKey: true,
-        ctrlKey: true,
-      });
-
-      editor.configuration.holder.dispatchEvent(keyboardEvent);
-
-      expect(undo.count()).toEqual(2);
-      expect(undo.position).toEqual(1);
-      const { state } = undo.stack[1];
-      expect(state).toEqual(firstChange.blocks);
-    });
-
-    it('undo event, with default shortcut if the shortcuts has been customized, inside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
-      undo.shortcut('ctrlKey+x', 'ctrlKey+c');
-      const keyboardEvent = new KeyboardEvent('keydown', {
-        key: 'z',
-        metaKey: true,
-        ctrlKey: true,
-      });
-
-      editor.configuration.holder.dispatchEvent(keyboardEvent);
-
-      expect(undo.count()).toEqual(2);
-      expect(undo.position).toEqual(2);
-      const { state } = undo.stack[2];
-      expect(state).toEqual(secondChange.blocks);
-    });
-
-    it('redo event, with default shortcut, outside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
+    it('redo event  outside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
       undo.undo();
 
       const keyboardEvent = new KeyboardEvent('keydown', {
@@ -214,7 +182,7 @@ describe('Undo', () => {
       expect(state).toEqual(firstChange.blocks);
     });
 
-    it('redo event, with default shortcut, inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
+    it('redo event inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
       undo.undo();
 
       const keyboardEvent = new KeyboardEvent('keydown', {
@@ -230,13 +198,39 @@ describe('Undo', () => {
       const { state } = undo.stack[2];
       expect(state).toEqual(secondChange.blocks);
     });
+  });
 
-    it('redo event, with custom shortcut, inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
-      undo.shortcut('ctrlKey+x', 'ctrlKey+c');
-      undo.undo();
 
+  describe('Undo/redo events fired with custom shortcuts', () => {
+    let undo;
+
+    beforeEach(() => {
+      editor.configuration.tools = tools;
+      const { config } = tools.undo;
+      undo = new Undo({ editor, config });
+      undo.initialize(initialData.blocks);
+      undo.save(firstChange.blocks);
+      undo.save(secondChange.blocks);
+    });
+
+    it('undo event inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
       const keyboardEvent = new KeyboardEvent('keydown', {
-        key: 'c',
+        key: 'x',
+        metaKey: true,
+        ctrlKey: true,
+      });
+
+      editor.configuration.holder.dispatchEvent(keyboardEvent);
+
+      expect(undo.count()).toEqual(2);
+      expect(undo.position).toEqual(1);
+      const { state } = undo.stack[1];
+      expect(state).toEqual(firstChange.blocks);
+    });
+
+    it('undo event, with default shortcut, inside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
+      const keyboardEvent = new KeyboardEvent('keydown', {
+        key: 'z',
         metaKey: true,
         ctrlKey: true,
       });
@@ -249,8 +243,24 @@ describe('Undo', () => {
       expect(state).toEqual(secondChange.blocks);
     });
 
-    it('redo event, with default shortcut if the shortcuts has been customized, inside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
-      undo.shortcut('ctrlKey+x', 'ctrlKey+c');
+    it('redo event inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
+      undo.undo();
+      const keyboardEvent = new KeyboardEvent('keydown', {
+        key: 'c',
+        metaKey: true,
+        ctrlKey: true,
+        altKey: true,
+      });
+
+      editor.configuration.holder.dispatchEvent(keyboardEvent);
+
+      expect(undo.count()).toEqual(2);
+      expect(undo.position).toEqual(2);
+      const { state } = undo.stack[2];
+      expect(state).toEqual(secondChange.blocks);
+    });
+
+    it('redo event, with default shortcut, inside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
       undo.undo();
       const keyboardEvent = new KeyboardEvent('keydown', {
         key: 'y',
@@ -266,6 +276,7 @@ describe('Undo', () => {
       expect(state).toEqual(firstChange.blocks);
     });
   });
+
 
   describe('the holder key accept strings', () => {
     let undo;

--- a/test/undo.test.js
+++ b/test/undo.test.js
@@ -134,7 +134,7 @@ describe('Undo', () => {
       undo.save(secondChange.blocks);
     });
 
-    it('undo event outside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
+    it('undo event, with default shortcut, outside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
       // Set metaKey and ctrlKey to true in order to work in Mac and other OSs.
       const keyboardEvent = new KeyboardEvent('keydown', {
         key: 'z',
@@ -150,7 +150,7 @@ describe('Undo', () => {
       expect(state).toEqual(secondChange.blocks);
     });
 
-    it('undo event inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
+    it('undo event, with default shortcut, inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
       const keyboardEvent = new KeyboardEvent('keydown', {
         key: 'z',
         metaKey: true,
@@ -165,7 +165,39 @@ describe('Undo', () => {
       expect(state).toEqual(firstChange.blocks);
     });
 
-    it('redo event outside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
+    it('undo event, with custom shortcut, inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
+      undo.shortcut('ctrlKey+x', 'ctrlKey+c');
+      const keyboardEvent = new KeyboardEvent('keydown', {
+        key: 'x',
+        metaKey: true,
+        ctrlKey: true,
+      });
+
+      editor.configuration.holder.dispatchEvent(keyboardEvent);
+
+      expect(undo.count()).toEqual(2);
+      expect(undo.position).toEqual(1);
+      const { state } = undo.stack[1];
+      expect(state).toEqual(firstChange.blocks);
+    });
+
+    it('undo event, with default shortcut if the shortcuts has been customized, inside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
+      undo.shortcut('ctrlKey+x', 'ctrlKey+c');
+      const keyboardEvent = new KeyboardEvent('keydown', {
+        key: 'z',
+        metaKey: true,
+        ctrlKey: true,
+      });
+
+      editor.configuration.holder.dispatchEvent(keyboardEvent);
+
+      expect(undo.count()).toEqual(2);
+      expect(undo.position).toEqual(2);
+      const { state } = undo.stack[2];
+      expect(state).toEqual(secondChange.blocks);
+    });
+
+    it('redo event, with default shortcut, outside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
       undo.undo();
 
       const keyboardEvent = new KeyboardEvent('keydown', {
@@ -182,7 +214,7 @@ describe('Undo', () => {
       expect(state).toEqual(firstChange.blocks);
     });
 
-    it('redo event inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
+    it('redo event, with default shortcut, inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
       undo.undo();
 
       const keyboardEvent = new KeyboardEvent('keydown', {
@@ -197,6 +229,41 @@ describe('Undo', () => {
       expect(undo.position).toEqual(2);
       const { state } = undo.stack[2];
       expect(state).toEqual(secondChange.blocks);
+    });
+
+    it('redo event, with custom shortcut, inside Editor\'s holder has to cause changes in Undo Plugin stack', () => {
+      undo.shortcut('ctrlKey+x', 'ctrlKey+c');
+      undo.undo();
+
+      const keyboardEvent = new KeyboardEvent('keydown', {
+        key: 'c',
+        metaKey: true,
+        ctrlKey: true,
+      });
+
+      editor.configuration.holder.dispatchEvent(keyboardEvent);
+
+      expect(undo.count()).toEqual(2);
+      expect(undo.position).toEqual(2);
+      const { state } = undo.stack[2];
+      expect(state).toEqual(secondChange.blocks);
+    });
+
+    it('redo event, with default shortcut if the shortcuts has been customized, inside Editor\'s holder has not to cause changes in Undo Plugin stack', () => {
+      undo.shortcut('ctrlKey+x', 'ctrlKey+c');
+      undo.undo();
+      const keyboardEvent = new KeyboardEvent('keydown', {
+        key: 'y',
+        metaKey: true,
+        ctrlKey: true,
+      });
+
+      editor.configuration.holder.dispatchEvent(keyboardEvent);
+
+      expect(undo.count()).toEqual(2);
+      expect(undo.position).toEqual(1);
+      const { state } = undo.stack[1];
+      expect(state).toEqual(firstChange.blocks);
     });
   });
 

--- a/test/undo.test.js
+++ b/test/undo.test.js
@@ -205,7 +205,6 @@ describe('Undo', () => {
     let undo;
 
     beforeEach(() => {
-      editor.configuration.tools = tools;
       const { config } = tools.undo;
       undo = new Undo({ editor, config });
       undo.initialize(initialData.blocks);


### PR DESCRIPTION
Main feature: 
Add a feature to customize the shortcuts to the undo and redo actions, keeping the default shortcuts if the user does not specify the shortcuts. 

Solution:
- Implement a method to set up the shortcuts, so the user has to call the method in onReady as follow: 
`onReady: () => {`
`const undo = new Undo({ editor });`
`undo.shortcut(shortcutUndo, shortcutRedo);`
`}`

- Add the respective test to the new feature
- fix #48 