### PR TITLE
Drag'n drop undo inconsistency when initial data has ids

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -280,7 +280,7 @@ export default class Undo {
         return;
       }
 
-      if (this.blockWasDropped(state, nextState) && this.position !== 0) {
+      if (this.blockWasDropped(state, nextState)) {
         this.blocks
           .render({ blocks: state })
           .then(() => this.caret.setToBlock(index, "end"));


### PR DESCRIPTION
closes #117 
remove a block position validation preventing blocks that were defined with an id to being drop consistently