### PR TITLE
Fix "master" branch by "main" in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - 'v*.[0-9]'
   pull_request:
 


### PR DESCRIPTION
### Description

The coverage badge is not showing because in the CI the branch is named "master" instead of "main".