### PR TITLE
Keep read-only permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   test:
-    permissions:
-      checks: write  # for coverallsapp/github-action to create new checks
-      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Keep read-only permissions in CI workflow

https://api.securityscorecards.dev/projects/github.com/kommitters/editorjs-undo
![image](https://user-images.githubusercontent.com/39246879/209832825-e469a850-e0b5-484a-86a4-330115431258.png)
