### PR TITLE
Prepare release v2.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.18 (13.01.2023)
+
+- Block egress traffic in GitHub Actions.
+- Add stability badge in README.
+
 ## 2.0.17 (28.12.2022)
 
 - Add Renovate as dependency update tool.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editorjs-undo",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "keywords": [
     "undo",
     "redo",


### PR DESCRIPTION
## 2.0.18 (13.01.2023)

- Block egress traffic in GitHub Actions.
- Add stability badge in README.