### PR TITLE
Update codeql.yml and scorecards.yml allowed-endpoints

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
+        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,9 +46,9 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
-            api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
+            *.github.com:443
+            *.githubapp.com:443
+            *.githubusercontent.com:443
 
       - name: Checkout repository
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -34,7 +34,9 @@ jobs:
             fulcio.sigstore.dev:443
             github.com:443
             rekor.sigstore.dev:443
-            sigstore-tuf-root.storage.googleapis.com:443
+            bestpractices.dev:443
+            pipelinesghubeus3.actions.githubusercontent.com:443
+            *.storage.googleapis.com:443
 
       - name: "Checkout code"
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
+        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
           disable-sudo: true
           egress-policy: block
@@ -35,7 +35,6 @@ jobs:
             github.com:443
             rekor.sigstore.dev:443
             bestpractices.dev:443
-            pipelinesghubeus3.actions.githubusercontent.com:443
             *.storage.googleapis.com:443
 
       - name: "Checkout code"


### PR DESCRIPTION
In this pull request, we are making a change to the allowed endpoints configuration. 

The updated allowed-endpoints configuration now includes the following endpoints:

codeqlyml
- api.github.com:443:
- *.githubapp.com:443:
- *.githubusercontent.com:443:

scorecards.yml
- bestpractices.dev:443
- pipelinesghubeus3.actions.githubusercontent.com:443
- *.storage.googleapis.com:443